### PR TITLE
chore: codeowners are same as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+####################################################
+#
+# List of approvers for observability-examples project
+#
+#####################################################
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users/teams will be requested for
+# review when someone opens a pull request.
+* @cisco-open/observability-examples-maintainers
+
+# TODO: assign code owners per subsystem
+
+# Enforces admin protections for repo configuration via probot settings app.
+# ref: https://github.com/probot/settings#security-implications
+.github/settings.yml @cisco-open/observability-examples-admins


### PR DESCRIPTION
## Description

Make the maintainers of the repo, code owners and default reviewers for the repo.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
